### PR TITLE
fix: numpy >=1.14.5 is required

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ dlib
 face_recognition
 youtube-dl
 moviepy
-numpy==1.14.0
+numpy==1.14.5
 tqdm
 pydot
 graphviz


### PR DESCRIPTION
Otherwise you get
> coremltools 4.0 requires numpy>=1.14.5, but you'll have numpy 1.14.0 which is incompatible.

when pip installing the requirements.